### PR TITLE
fix: 统一版本JDK8起步

### DIFF
--- a/generator-plugins/pom.xml
+++ b/generator-plugins/pom.xml
@@ -36,10 +36,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>6</source>
-                    <target>6</target>
-                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
统一插件、入口、生成等功能模块为JDK8起步，避免后期不必要的问题